### PR TITLE
Apple Native: fix getAssetByFilePath for files with no extension

### DIFF
--- a/resources/src/appleMain/kotlin/dev/icerock/moko/resources/ResourceContainerExt.kt
+++ b/resources/src/appleMain/kotlin/dev/icerock/moko/resources/ResourceContainerExt.kt
@@ -6,7 +6,7 @@ package dev.icerock.moko.resources
 
 actual fun ResourceContainer<AssetResource>.getAssetByFilePath(filePath: String): AssetResource? {
     //get name without extension and extension
-    val ext = filePath.substringAfterLast('.')
+    val ext = filePath.substringAfterLast('.', "")
     val name = filePath.substringBeforeLast('.')
         .replace('/', '+')
 


### PR DESCRIPTION
`substringAfterLast` returns `missingDelimiterValue` which defaults to the original string. `missingDelimiterValue` should be an empty string when there is no file extension